### PR TITLE
Allow specifying `.` for the target path to save to source folder

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -14,14 +14,16 @@ test('retrieveCodes', async() => {
             code: `@startuml
 A -> B: test1
 @enduml
-`
+`,
+            dir: '__tests__/assets'
         },
         {
             name: 'test_2',
             code: `@startuml
 A -> B: test2
 @enduml
-`
+`,
+            dir: '__tests__/assets'
         },
         {
             name: 'test.4',
@@ -29,7 +31,8 @@ A -> B: test2
 [Prototype design] lasts 15 days
 [Test prototype] lasts 10 days
 @endgantt
-`
+`,
+            dir: '__tests__/assets'
         },
         {
             name: 'test3',
@@ -37,7 +40,8 @@ A -> B: test2
 A -> B: test3
 B -> C: test3
 @enduml
-`
+`,
+            dir: '__tests__/assets'
         }
     ]);
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ const octokit = new github.GitHub(process.env.GITHUB_TOKEN);
     let tree: any[] = [];
     for (const plantumlCode of plantumlCodes) {
         const p = path.format({
-            dir: diagramPath,
+            dir: (diagramPath === '.') ? plantumlCode.dir : diagramPath,
             name: plantumlCode.name,
             ext: '.svg'
         });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,12 +11,19 @@ export function retrieveCodes(files) {
                 name: p.name,
                 // TODO: files may have been deleted.
                 code: fs.readFileSync(f).toString(),
+                dir: p.dir
             });
         }
         if (p.ext === '.md') {
             // TODO: files may have been deleted.
             const content = fs.readFileSync(f).toString();
-            return accum.concat(puFromMd(content));
+            const dir = path.dirname(f);
+            const codes = puFromMd(content);
+            codes.forEach(code => {
+                code.dir = path.dirname(f)
+                return code;
+            })
+            return accum.concat(codes);
         }
         return p.ext === '.md' ? accum.concat(f) : accum
     }, []);


### PR DESCRIPTION
Currently the resulting image files are committed to a dedicated
folder specified by the `path` option.

This change adds the option to specify `.` as the value for `path`
in which case the rendered SVG images are stored in the same folder
as the source file it was generated from. This works for both
inline plantuml blocks as well as separate files.