### PR TITLE
Ignore deleted files in changeset

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -114,16 +114,26 @@ test('updatedFiles', async() => {
         {
             "files": [
                 {
+                    "status": "added",
                     "filename": "file1.txt",
                 },
                 {
+                    "status": "modified",
                     "filename": "file2.txt",
+                },
+                {
+                    "status": "removed",
+                    "filename": "file3.txt",
+                },
+                {
+                    "status": "renamed",
+                    "filename": "file4.txt",
                 },
             ],
             "sha": "b",
         }
     ]);
-    await expect(files).toEqual([ 'file1.txt', 'file2.txt' ]);
+    await expect(files).toEqual([ 'file1.txt', 'file2.txt', 'file4.txt' ]);
 });
 
 const octokitMock = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,8 +91,8 @@ export async function getCommitsFromPayload(octokit, payload) {
 }
 
 export function updatedFiles(commits) {
-    return uniq(commits.reduce(
-        (accum: any[], commit) => accum.concat(commit.files.map(f => f.filename)),
+    return uniq(commits.reduce((accum: any[], commit) => accum.concat(
+        commit.files.filter(f => f.status !== 'removed').map(f => f.filename)),
         []
     ));
 }


### PR DESCRIPTION
This change prevents deleted files from the changeset to enter
the list of files to be processed, thereby preventing an error
because these files cannot be found.